### PR TITLE
Fix ESLint trailing comma warnings

### DIFF
--- a/packages/@core/base/icons/build.config.ts
+++ b/packages/@core/base/icons/build.config.ts
@@ -3,5 +3,5 @@ import { defineBuildConfig } from 'unbuild';
 export default defineBuildConfig({
   clean: true,
   declaration: true,
-  entries: ['src/index'],
+  entries: ['src/index']
 });

--- a/packages/@core/base/icons/src/create-icon.ts
+++ b/packages/@core/base/icons/src/create-icon.ts
@@ -7,7 +7,7 @@ function createIconifyIcon(icon: string) {
     name: `Icon-${icon}`,
     setup(props, { attrs }) {
       return () => h(Icon, { icon, ...props, ...attrs });
-    },
+    }
   });
 }
 

--- a/packages/@core/base/icons/src/index.ts
+++ b/packages/@core/base/icons/src/index.ts
@@ -7,5 +7,5 @@ export {
   addCollection,
   addIcon,
   Icon as IconifyIcon,
-  listIcons,
+  listIcons
 } from '@iconify/vue';

--- a/packages/@core/base/icons/src/lucide.ts
+++ b/packages/@core/base/icons/src/lucide.ts
@@ -64,5 +64,5 @@ export {
   SunMoon,
   SwatchBook,
   UserRoundPen,
-  X,
+  X
 } from 'lucide-vue-next';

--- a/packages/@core/base/shared/build.config.ts
+++ b/packages/@core/base/shared/build.config.ts
@@ -9,6 +9,6 @@ export default defineBuildConfig({
     'src/utils/index',
     'src/color/index',
     'src/cache/index',
-    'src/global-state',
-  ],
+    'src/global-state'
+  ]
 });

--- a/packages/@core/base/shared/src/cache/storage-manager.ts
+++ b/packages/@core/base/shared/src/cache/storage-manager.ts
@@ -16,7 +16,7 @@ class StorageManager {
 
   constructor({
     prefix = '',
-    storageType = 'localStorage',
+    storageType = 'localStorage'
   }: StorageManagerOptions = {}) {
     this.prefix = prefix;
     this.storage =

--- a/packages/utils/src/helpers/find-menu-by-path.ts
+++ b/packages/utils/src/helpers/find-menu-by-path.ts
@@ -2,7 +2,7 @@ import type { MenuRecordRaw } from '@vben-core/typings';
 
 function findMenuByPath(
   list: MenuRecordRaw[],
-  path?: string,
+  path?: string
 ): MenuRecordRaw | null {
   for (const menu of list) {
     if (menu.path === path) {
@@ -31,7 +31,7 @@ function findRootMenuByPath(menus: MenuRecordRaw[], path?: string, level = 0) {
   return {
     findMenu,
     rootMenu,
-    rootMenuPath,
+    rootMenuPath
   };
 }
 

--- a/packages/utils/src/helpers/generate-menus.ts
+++ b/packages/utils/src/helpers/generate-menus.ts
@@ -3,7 +3,7 @@ import type { Router, RouteRecordRaw } from 'vue-router';
 import type {
   ExRouteRecordRaw,
   MenuRecordRaw,
-  RouteMeta,
+  RouteMeta
 } from '@vben-core/typings';
 
 import { filterTree, mapTree } from '@vben-core/shared/utils';
@@ -16,11 +16,11 @@ import { filterTree, mapTree } from '@vben-core/shared/utils';
  */
 function generateMenus(
   routes: RouteRecordRaw[],
-  router: Router,
+  router: Router
 ): MenuRecordRaw[] {
   // 将路由列表转换为一个以 name 为键的对象映射
   const finalRoutesMap: { [key: string]: string } = Object.fromEntries(
-    router.getRoutes().map(({ name, path }) => [name, path]),
+    router.getRoutes().map(({ name, path }) => [name, path])
   );
 
   let menus = mapTree<ExRouteRecordRaw, MenuRecordRaw>(routes, (route) => {
@@ -31,7 +31,7 @@ function generateMenus(
       meta = {} as RouteMeta,
       name: routeName,
       redirect,
-      children = [],
+      children = []
     } = route;
     const {
       activeIcon,
@@ -42,7 +42,7 @@ function generateMenus(
       icon,
       link,
       order,
-      title = '',
+      title = ''
     } = meta;
 
     // 确保菜单名称不为空
@@ -76,7 +76,7 @@ function generateMenus(
       parents: route.parents,
       path: resultPath,
       show: !meta.hideInMenu,
-      children: resultChildren,
+      children: resultChildren
     };
   });
 

--- a/packages/utils/src/helpers/generate-routes-backend.ts
+++ b/packages/utils/src/helpers/generate-routes-backend.ts
@@ -3,7 +3,7 @@ import type { RouteRecordRaw } from 'vue-router';
 import type {
   ComponentRecordType,
   GenerateMenuAndRoutesOptions,
-  RouteRecordStringComponent,
+  RouteRecordStringComponent
 } from '@vben-core/typings';
 
 import { mapTree } from '@vben-core/shared/utils';
@@ -12,7 +12,7 @@ import { mapTree } from '@vben-core/shared/utils';
  * 动态生成路由 - 后端方式
  */
 async function generateRoutesByBackend(
-  options: GenerateMenuAndRoutesOptions,
+  options: GenerateMenuAndRoutesOptions
 ): Promise<RouteRecordRaw[]> {
   const { fetchMenuListAsync, layoutMap = {}, pageMap = {} } = options;
 
@@ -38,7 +38,7 @@ async function generateRoutesByBackend(
 function convertRoutes(
   routes: RouteRecordStringComponent[],
   layoutMap: ComponentRecordType,
-  pageMap: ComponentRecordType,
+  pageMap: ComponentRecordType
 ): RouteRecordRaw[] {
   return mapTree(routes, (node) => {
     const route = node as unknown as RouteRecordRaw;

--- a/packages/utils/src/helpers/generate-routes-frontend.ts
+++ b/packages/utils/src/helpers/generate-routes-frontend.ts
@@ -8,7 +8,7 @@ import { filterTree, mapTree } from '@vben-core/shared/utils';
 async function generateRoutesByFrontend(
   routes: RouteRecordRaw[],
   roles: string[],
-  forbiddenComponent?: RouteRecordRaw['component'],
+  forbiddenComponent?: RouteRecordRaw['component']
 ): Promise<RouteRecordRaw[]> {
   // 根据角色标识过滤路由表,判断当前用户是否拥有指定权限
   const finalRoutes = filterTree(routes, (route) => {

--- a/packages/utils/src/helpers/merge-route-modules.ts
+++ b/packages/utils/src/helpers/merge-route-modules.ts
@@ -11,7 +11,7 @@ interface RouteModuleType {
  * @returns 合并后的路由配置数组
  */
 function mergeRouteModules(
-  routeModules: Record<string, unknown>,
+  routeModules: Record<string, unknown>
 ): RouteRecordRaw[] {
   const mergedRoutes: RouteRecordRaw[] = [];
 

--- a/packages/utils/src/helpers/reset-routes.ts
+++ b/packages/utils/src/helpers/reset-routes.ts
@@ -14,7 +14,7 @@ export function resetStaticRoutes(router: Router, routes: RouteRecordRaw[]) {
     // 这些路由需要指定 name，防止在路由重置时，不能删除没有指定 name 的路由
     if (!route.name) {
       console.warn(
-        `The route with the path ${route.path} needs to have the field name specified.`,
+        `The route with the path ${route.path} needs to have the field name specified.`
       );
     }
     return route.name;

--- a/packages/utils/src/helpers/unmount-global-loading.ts
+++ b/packages/utils/src/helpers/unmount-global-loading.ts
@@ -15,7 +15,7 @@ export function unmountGlobalLoading() {
 
     // 查找所有需要移除的注入 loading 元素
     const injectLoadingElements = document.querySelectorAll(
-      '[data-app-loading^="inject"]',
+      '[data-app-loading^="inject"]'
     );
 
     // 当过渡动画结束时，移除 loading 元素和所有注入的 loading 元素
@@ -25,7 +25,7 @@ export function unmountGlobalLoading() {
         loadingElement.remove(); // 移除 loading 元素
         injectLoadingElements.forEach((el) => el.remove()); // 移除所有注入的 loading 元素
       },
-      { once: true },
+      { once: true }
     ); // 确保事件只触发一次
   }
 }


### PR DESCRIPTION
## Summary
- remove disallowed trailing commas reported by ESLint
- keep object and function syntax consistent

## Testing
- `pnpm exec eslint packages/@core/base/icons/build.config.ts packages/@core/base/icons/src/create-icon.ts packages/@core/base/icons/src/index.ts packages/@core/base/icons/src/lucide.ts packages/@core/base/shared/build.config.ts packages/@core/base/shared/src/cache/storage-manager.ts packages/utils/src/helpers/*.ts --format stylish`
- `pnpm -r run typecheck` *(fails: playground typecheck: errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843ce4a4bd483239b10b881362a36b0