### PR TITLE
Fix async usage and lint type errors

### DIFF
--- a/internal/lint-configs/eslint-config/src/configs/typescript.ts
+++ b/internal/lint-configs/eslint-config/src/configs/typescript.ts
@@ -3,10 +3,15 @@ import type { Linter } from 'eslint';
 import { interopDefault } from '../util';
 
 export async function typescript(): Promise<Linter.Config[]> {
-  const [pluginTs, parserTs] = await Promise.all([
-    interopDefault(import('@typescript-eslint/eslint-plugin')),
-    interopDefault(import('@typescript-eslint/parser'))
-  ] as const);
+  const pluginTsPromise = interopDefault(
+    import('@typescript-eslint/eslint-plugin')
+  );
+  const parserTsPromise = interopDefault(import('@typescript-eslint/parser'));
+
+  const [pluginTs, parserTs] = (await Promise.all([
+    pluginTsPromise,
+    parserTsPromise
+  ])) as [Linter.Plugin, any];
 
   return [
     {

--- a/internal/lint-configs/eslint-config/src/configs/unicorn.ts
+++ b/internal/lint-configs/eslint-config/src/configs/unicorn.ts
@@ -3,9 +3,10 @@ import type { Linter } from 'eslint';
 import { interopDefault } from '../util';
 
 export async function unicorn(): Promise<Linter.Config[]> {
-  const [pluginUnicorn] = await Promise.all([
-    interopDefault(import('eslint-plugin-unicorn'))
-  ] as const);
+  const pluginUnicornPromise = interopDefault(
+    import('eslint-plugin-unicorn')
+  );
+  const [pluginUnicorn] = await Promise.all([pluginUnicornPromise]);
 
   return [
     {

--- a/internal/lint-configs/eslint-config/src/configs/vue.ts
+++ b/internal/lint-configs/eslint-config/src/configs/vue.ts
@@ -3,14 +3,17 @@ import type { Linter } from 'eslint';
 import { interopDefault } from '../util';
 
 export async function vue(): Promise<Linter.Config[]> {
+  const pluginVuePromise = interopDefault(import('eslint-plugin-vue'));
+  const parserVuePromise = interopDefault(import('vue-eslint-parser'));
+  /**
+   * @ts-expect-error missing types
+   */
+  const parserTsPromise = interopDefault(import('@typescript-eslint/parser'));
   const [pluginVue, parserVue, parserTs] = await Promise.all([
-    interopDefault(import('eslint-plugin-vue')),
-    interopDefault(import('vue-eslint-parser')),
-    /**
-     * @ts-expect-error missing types
-     */
-    interopDefault(import('@typescript-eslint/parser'))
-  ] as const);
+    pluginVuePromise,
+    parserVuePromise,
+    parserTsPromise
+  ]);
 
   const flatEssential = pluginVue.configs?.['flat/essential'] || [];
   const flatStronglyRecommended =

--- a/packages/effects/layouts/src/basic/menu/use-mixed-menu.ts
+++ b/packages/effects/layouts/src/basic/menu/use-mixed-menu.ts
@@ -84,9 +84,9 @@ function useMixedMenu() {
    * @param key 菜单路径
    * @param mode 菜单模式
    */
-  const handleMenuSelect = (key: string, mode?: string) => {
+  const handleMenuSelect = async (key: string, mode?: string) => {
     if (!needSplit.value || mode === 'vertical') {
-      navigation(key);
+      await navigation(key);
       return;
     }
     const rootMenu = menus.value.find((item) => item.path === key);
@@ -98,9 +98,9 @@ function useMixedMenu() {
     }
 
     if (_splitSideMenus.length === 0) {
-      navigation(key);
+      await navigation(key);
     } else if (rootMenu && preferences.sidebar.autoActivateChild) {
-      navigation(
+      await navigation(
         defaultSubMap.has(rootMenu.path)
           ? (defaultSubMap.get(rootMenu.path) as string)
           : rootMenu.path
@@ -113,9 +113,9 @@ function useMixedMenu() {
    * @param key 路由路径
    * @param parentsPath 父级路径
    */
-  const handleMenuOpen = (key: string, parentsPath: string[]) => {
+  const handleMenuOpen = async (key: string, parentsPath: string[]) => {
     if (parentsPath.length <= 1 && preferences.sidebar.autoActivateChild) {
-      navigation(
+      await navigation(
         defaultSubMap.has(key) ? (defaultSubMap.get(key) as string) : key
       );
     }

--- a/packages/effects/layouts/src/basic/tabbar/use-tabbar.ts
+++ b/packages/effects/layouts/src/basic/tabbar/use-tabbar.ts
@@ -75,9 +75,9 @@ export function useTabbar() {
   };
 
   // 点击tab,跳转路由
-  const handleClick = (key: string) => {
+  const handleClick = async (key: string) => {
     const { fullPath, path } = tabbarStore.getTabByKey(key);
-    router.push(fullPath || path);
+    await router.push(fullPath || path);
   };
 
   // 关闭tab

--- a/packages/effects/layouts/src/widgets/preferences/preferences-drawer.vue
+++ b/packages/effects/layouts/src/widgets/preferences/preferences-drawer.vue
@@ -177,7 +177,7 @@ const {
 } = usePreferences();
 const { copy } = useClipboard({ legacy: true });
 
-const [Drawer] = useVbenDrawer();
+const [Drawer] = await useVbenDrawer();
 
 const activeTab = ref('appearance');
 

--- a/packages/effects/layouts/src/widgets/preferences/preferences.vue
+++ b/packages/effects/layouts/src/widgets/preferences/preferences.vue
@@ -11,7 +11,7 @@ import { VbenButton } from '@vben-core/shadcn-ui';
 
 import PreferencesDrawer from './preferences-drawer.vue';
 
-const [Drawer, drawerApi] = useVbenDrawer({
+const [Drawer, drawerApi] = await useVbenDrawer({
   connectedComponent: PreferencesDrawer
 });
 


### PR DESCRIPTION
## Summary
- ensure asynchronous plugin imports await results
- handle navigation promises in mixed menu
- await router push when switching tab
- await drawer helpers in preferences widgets

## Testing
- `pnpm run check:type` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f4e5a7248323a614b2eefea32ea1